### PR TITLE
Disconnect gracefully when error occures

### DIFF
--- a/web-client/public/js/ble.js
+++ b/web-client/public/js/ble.js
@@ -43,8 +43,13 @@ async function onButtonClick() {
       console.log('Waiting 60 seconds to receive data from the device...')
       await sleep(60 * 1000);
     }
-  } catch(error) {
-    console.log('Argh! ' + error);
+  } finally {
+    if (device) {
+      if (device.gatt.connected) {
+        device.gatt.disconnect();
+        console.log('disconnect');
+      }
+    }
   }
   
   if (device) {


### PR DESCRIPTION
Instead of printing the error, you can gracefully disconnect every time with finally. The console will look liek this in event of an error:

```
ble.js:7 Requesting Bluetooth Device...
ble.js:15 Connecting to GATT Server...
ble.js:18 Getting Service...
ble.js:21 Getting Characteristics...
ble.js:27 Reading Characteristics...
ble.js:30 hi!
ble.js:50 disconnect
ble.js:54 Uncaught (in promise) DOMException: GATT Error: Not supported.
    onButtonClick @ ble.js:54
    await in onButtonClick (async)
    onclick @ index.html:10
```